### PR TITLE
Refactor netcat

### DIFF
--- a/nclib/netcat.py
+++ b/nclib/netcat.py
@@ -160,11 +160,11 @@ class Netcat(object):
         self.peer = None
 
         # case: Netcat(host, port)
-        if type(connect) is str and type(listen) is int:
+        if isinstance(connect, str) and isinstance(listen, int):
             connect = (connect, listen)
 
         # case: Netcat(sock)
-        if type(connect) is socket.socket:
+        if isinstance(connect, socket.socket):
             sock = connect
             connect = None
 
@@ -212,7 +212,7 @@ class Netcat(object):
         possible from target. Returns a tuple that is its arguments but
         sanitized.
         """
-        if type(target) is str:
+        if isinstance(target, str):
             if target.startswith('nc '):
                 out_host = None
                 out_port = None
@@ -321,7 +321,7 @@ class Netcat(object):
 
                 return (addr, port), listen, udp, ipv6
 
-        elif type(target) in (int, long):
+        elif isinstance(target, (int, long)):
             if listen:
                 out_port = target
             else:
@@ -329,8 +329,8 @@ class Netcat(object):
 
             return ('::' if ipv6 else '0.0.0.0', out_port), listen, udp, ipv6
 
-        elif type(target) is tuple:
-            if len(target) >= 1 and type(target[0]) is str and is_ipv6_addr(target[0]):
+        elif isinstance(target, tuple):
+            if len(target) >= 1 and isinstance(target[0], str) and _is_ipv6_addr(target[0]):
                 ipv6 = True
             return target, listen, udp, ipv6
 
@@ -706,7 +706,8 @@ class Netcat(object):
 
         Aliases: recvline, readline, read_line, readln, recvln
         """
-        if ending is None: ending = self.LINE_ENDING
+        if ending is None:
+            ending = self.LINE_ENDING
         return self.recv_until(ending, max_size, timeout)
 
     def send_line(self, line, ending=None):
@@ -716,7 +717,8 @@ class Netcat(object):
 
         Aliases: sendline, writeline, write_line, writeln, sendln
         """
-        if ending is None: ending = self.LINE_ENDING
+        if ending is None:
+            ending = self.LINE_ENDING
         return self.send(line + ending)
 
     read = recv

--- a/nclib/netcat.py
+++ b/nclib/netcat.py
@@ -379,16 +379,6 @@ class Netcat(object):
                     break
             self.peer = target
 
-    def _head_buf(self, index=None):
-        if index is None:
-            out = self.buf
-            self.buf = ''
-            return out
-        else:
-            out = self.buf[:index]
-            self.buf = self.buf[index:]
-            return out
-
     def close(self):
         """
         Close the socket.
@@ -505,6 +495,57 @@ class Netcat(object):
         else:
             raise ValueError("I don't know how to read from this stream!")
 
+    def _recv_predicate(self, predicate, timeout='default', raise_eof=True):
+        """
+        Receive until predicate returns a positive integer.
+        The returned number is the size to return.
+        """
+
+        if timeout == 'default':
+            timeout = self._timeout
+
+        self.timed_out = False
+
+        start = time.time()
+        try:
+            while True:
+                cut_at = predicate(self.buf)
+                if cut_at > 0:
+                    break
+                if timeout is not None:
+                    time_elapsed = time.time() - start
+                    if time_elapsed > timeout:
+                        raise socket.timeout
+                    self._settimeout(timeout - time_elapsed)
+
+                data = self._recv(4096)
+                if not data:
+                    if raise_eof:
+                        raise NetcatError("Connection dropped!")
+                    cut_at = len(self.buf)
+                    break
+
+                self._log_recv(data, False)
+
+                self.buf += data
+        except KeyboardInterrupt:
+            if self.verbose and self.echo_headers:
+                print('\n======== Connection interrupted! ========')
+        except socket.timeout:
+            self.timed_out = True
+            if self._raise_timeout:
+                raise NetcatTimeout()
+            return b''
+        except socket.error as exc:
+            raise NetcatError('Socket error: %r' % exc)
+
+        self._settimeout(self._timeout)
+
+        ret = self.buf[:cut_at]
+        self.buf = self.buf[cut_at:]
+        self._log_recv(ret, True)
+        return ret
+
     def _settimeout(self, timeout):
         """
         Internal method - catches failures when working with non-timeoutable
@@ -527,7 +568,6 @@ class Netcat(object):
 
         Aliases: read, get
         """
-        self.timed_out = False
 
         if self.verbose and self.echo_headers:
             if timeout:
@@ -535,39 +575,7 @@ class Netcat(object):
             else:
                 print('======== Receiving {0}B ========'.format(n))
 
-        ret = b''
-        if self.buf:
-            ret = self.buf[:n]
-            self.buf = self.buf[n:]
-            self._log_recv(ret, True)
-            return ret
-
-        try:
-            if timeout != 'default':
-                self._settimeout(timeout)
-
-            a = self._recv(n - len(self.buf))
-            if a == b'':
-                raise NetcatError("Connection dropped!")
-            self._log_recv(a, False)
-
-            self.buf += a
-            ret = self.buf
-            self.buf = b''
-        except socket.timeout:
-            self.timed_out = True
-            if self._raise_timeout:
-                raise NetcatTimeout()
-        except socket.error as e:
-            raise NetcatError('Socket error: %r' % e)
-
-        self._settimeout(self._timeout)
-
-        if not timeout and ret == b'':
-            raise NetcatError("Connection dropped!")
-
-        self._log_recv(ret, True)
-        return ret
+        return self._recv_predicate(lambda s: min(n, len(s)), timeout)
 
     def recv_until(self, s, max_size=None, timeout='default'):
         """
@@ -577,7 +585,6 @@ class Netcat(object):
 
         Aliases: read_until, readuntil, recvuntil
         """
-        self.timed_out = False
         if timeout == 'default':
             timeout = self._timeout
 
@@ -589,37 +596,15 @@ class Netcat(object):
                 print('======== Receiving until {0} ========'
                         .format(repr(s)))
 
-        start = time.time()
-        try:
-            while s not in self.buf \
-                    and (max_size is None or len(self.buf) < max_size):
-                if timeout is not None:
-                    dt = time.time()-start
-                    if dt > timeout:
-                        self.timed_out = True
-                        break
-                    self._settimeout(timeout-dt)
+        if max_size is None:
+            max_size = 2 ** 62
 
-                a = self._recv(4096)
-                if a == b'':
-                    raise NetcatError("Connection dropped!")
-                self._log_recv(a, False)
-
-                self.buf += a
-        except socket.timeout:
-            self.timed_out = True
-            if self._raise_timeout:
-                raise NetcatTimeout()
-
-        self._settimeout(self._timeout)
-
-        cut_at = self.buf.index(s)+len(s)
-        if max_size is not None:
-            cut_at = min(cut_at, max_size)
-
-        ret = self._head_buf(cut_at if not self.timed_out else None)
-        self._log_recv(ret, True)
-        return ret
+        def _predicate(buf):
+            try:
+                return min(buf.index(s) + len(s), max_size)
+            except ValueError:
+                return 0 if len(buf) < max_size else max_size
+        return self._recv_predicate(_predicate, timeout)
 
     def recv_all(self, timeout='default'):
         """
@@ -627,7 +612,6 @@ class Netcat(object):
 
         Aliases: read_all, readall, recvall
         """
-        self.timed_out = False
         if timeout == 'default':
             timeout = self._timeout
 
@@ -638,37 +622,7 @@ class Netcat(object):
             else:
                 print('======== Receiving until close ========')
 
-        start = time.time()
-        try:
-            while True:
-                if timeout is not None:
-                    dt = time.time()-start
-                    if dt > timeout:
-                        self.timed_out = True
-                        break
-                    self._settimeout(timeout-dt)
-
-                a = self._recv(4096)
-                if not a: break
-                self.buf += a
-                self._log_recv(a, False)
-
-        except KeyboardInterrupt:
-            if self.verbose and self.echo_headers:
-                print('\n======== Connection interrupted! ========')
-        except socket.timeout:
-            self.timed_out = True
-            if self._raise_timeout:
-                raise NetcatTimeout()
-        except (socket.error, NetcatError):
-            if self.verbose and self.echo_headers:
-                print('\n======== Connection dropped! ========')
-
-        self._settimeout(self._timeout)
-        ret = self.buf
-        self.buf = b''
-        self._log_recv(ret, True)
-        return ret
+        return self._recv_predicate(lambda s: 0, timeout, raise_eof=False)
 
     def recv_exactly(self, n, timeout='default'):
         """
@@ -676,7 +630,6 @@ class Netcat(object):
 
         Aliases: read_exactly, readexactly, recvexactly
         """
-        self.timed_out = False
         if timeout == 'default':
             timeout = self._timeout
 
@@ -688,36 +641,7 @@ class Netcat(object):
                 print('======== Receiving until exactly {0}B  ========'
                         .format(n))
 
-        start = time.time()
-        try:
-            while len(self.buf) < n:
-                if timeout is not None:
-                    dt = time.time()-start
-                    if dt > timeout:
-                        self.timed_out = True
-                        break
-                    self._settimeout(timeout-dt)
-
-                a = self._recv(n - len(self.buf))
-                if len(a) == 0:
-                    raise NetcatError("Connection closed before {0} bytes received!"
-                            .format(n))
-                self.buf += a
-                self._log_recv(a, False)
-        except KeyboardInterrupt:
-            if self.verbose and self.echo_headers:
-                print('\n======== Connection interrupted! ========')
-        except socket.timeout:
-            self.timed_out = True
-            if self._raise_timeout:
-                raise NetcatTimeout()
-        except socket.error as e:
-            raise NetcatError("Socket error: %r" % e)
-
-        out = self.buf[:n]
-        self.buf = self.buf[n:]
-        self._log_recv(out, True)
-        return out
+        return self._recv_predicate(lambda s: n if len(s) >= n else 0, timeout)
 
     def send(self, s):
         """
@@ -783,7 +707,7 @@ class Netcat(object):
 
     LINE_ENDING = b'\n'
 
-    def recv_line(self, max_size=None, timeout=None, ending=None):
+    def recv_line(self, max_size=None, timeout='default', ending=None):
         """
         Recieve until the next newline , default "\\n". The newline string can
         be changed by changing ``nc.LINE_ENDING``. The newline will be returned

--- a/nclib/netcat.py
+++ b/nclib/netcat.py
@@ -26,12 +26,12 @@ KNOWN_SCHEMES = {
 }
 
 if str is not bytes: # py3
-    long = int # pylint: disable=redefined-builtin
+    long = int # pylint: disable=redefined-builtin,invalid-name
     from urllib.parse import urlparse # pylint: disable=no-name-in-module,import-error
 else:
-    from urlparse import urlparse
+    from urlparse import urlparse # pylint: disable=import-error
 
-def is_ipv6_addr(addr):
+def _is_ipv6_addr(addr):
     try:
         socket.inet_pton(socket.AF_INET6, addr)
     except socket.error:
@@ -130,18 +130,18 @@ class Netcat(object):
     >>> nc.interact()
     """
     def __init__(self,
-            connect=None,
-            sock=None,
-            listen=None,
-            server=None,
-            udp=False,
-            ipv6=False,
-            verbose=0,
-            log_send=None,
-            log_recv=None,
-            raise_timeout=False,
-            retry=False,
-            log_yield=False):
+                 connect=None,
+                 sock=None,
+                 listen=None,
+                 server=None,
+                 udp=False,
+                 ipv6=False,
+                 verbose=0,
+                 log_send=None,
+                 log_recv=None,
+                 raise_timeout=False,
+                 retry=False,
+                 log_yield=False):
         self.buf = b''
 
         self.verbose = verbose
@@ -174,7 +174,7 @@ class Netcat(object):
 
         if sock is None and listen is None and connect is None:
             raise ValueError('Not enough arguments, need at least an '
-                    'address or a socket or a listening address!')
+                             'address or a socket or a listening address!')
 
         ## we support passing connect as the "name" of the socket
         #if sock is not None and (listen is not None or connect is not None):
@@ -258,7 +258,7 @@ class Netcat(object):
                 if out_port is None:
                     raise ValueError("Missing port: %s" % target)
 
-                if is_ipv6_addr(out_host):
+                if _is_ipv6_addr(out_host):
                     ipv6 = True
 
                 return (out_host, out_port), listen, udp, ipv6
@@ -293,7 +293,7 @@ class Netcat(object):
                 if addr is None or port is None:
                     raise ValueError("Can't parse addr/port from %s" % target)
 
-                if is_ipv6_addr(addr):
+                if _is_ipv6_addr(addr):
                     ipv6 = True
 
                 return (addr, port), listen, udp, ipv6
@@ -316,7 +316,7 @@ class Netcat(object):
                 if port is None:
                     raise ValueError("No port given: %s" % target)
 
-                if is_ipv6_addr(addr):
+                if _is_ipv6_addr(addr):
                     ipv6 = True
 
                 return (addr, port), listen, udp, ipv6
@@ -363,15 +363,15 @@ class Netcat(object):
             while True:
                 try:
                     self.sock.connect(target)
-                except (socket.gaierror, socket.herror) as e:
+                except (socket.gaierror, socket.herror) as exc:
                     raise NetcatError('Could not connect to %r: %r' \
-                            % (target, e))
-                except socket.error as e:
+                            % (target, exc))
+                except socket.error as exc:
                     if retry:
                         time.sleep(0.2)
                     else:
                         raise NetcatError('Could not connect to %r: %r' \
-                                % (target, e))
+                                % (target, exc))
                 else:
                     break
             self.peer = target
@@ -509,11 +509,11 @@ class Netcat(object):
         else:
             raise ValueError("I don't know how to write to this stream!")
 
-    def _recv(self, n):
+    def _recv(self, size):
         if hasattr(self.sock, 'recv'):
-            return self.sock.recv(n)
+            return self.sock.recv(size)
         elif hasattr(self.sock, 'read'):
-            return self.sock.read(n)    # pylint: disable=no-member
+            return self.sock.read(size)    # pylint: disable=no-member
         else:
             raise ValueError("I don't know how to read from this stream!")
 


### PR DESCRIPTION
Spent one night refactoring netcat and fixing bugs I stumble upon
* Unify implementation of recv* (with 4 copies I doubt it was maintainable)
* Unify all print (so printing to stderr/StringIO can be supported easily)
* Improve pylint score (because I see some `# pylint:disable=`)

Warning: actual refactors, bug fixes and pylint fixes are mixed together